### PR TITLE
Add option to exclude h1 from numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-[![Actions Status](https://github.com/timvink/mkdocs-enumerate-headings-plugin/workflows/pytest/badge.svg)](https://github.com/timvink/mkdocs-enumerate-headings-plugin/actions)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mkdocs-enumerate-headings-plugin)
-![PyPI](https://img.shields.io/pypi/v/mkdocs-enumerate-headings-plugin)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/mkdocs-enumerate-headings-plugin)
-[![codecov](https://codecov.io/gh/timvink/mkdocs-enumerate-headings-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/timvink/mkdocs-enumerate-headings-plugin)
-![GitHub contributors](https://img.shields.io/github/contributors/timvink/mkdocs-enumerate-headings-plugin)
-![PyPI - License](https://img.shields.io/pypi/l/mkdocs-enumerate-headings-plugin)
+# Rowden fork of `mkdocs-enumerate-headings-plugin`
+This adds a feature to disable counting h1 headings in numbering.
+
+To use, in requirements.txt:
+```
+mkdocs-enumerate-headings-plugin @ git+https://github.com/rowdentech/mkdocs-enumerate-headings-plugin@rowden
+```
+
+`master` is kept clean to allow us to pull in upstream changes easily. Any futher modification here should target the `rowden` branch.
+
+---
 
 # mkdocs-enumerate-headings-plugin
 

--- a/mkdocs_enumerate_headings_plugin/heading.py
+++ b/mkdocs_enumerate_headings_plugin/heading.py
@@ -52,7 +52,7 @@ class Heading:
 
         self.section_numbering[0] = new_chapter
 
-    def section_number_string(self):
+    def section_number_string(self, exclude_h1=False):
         """
         Translate section numbering to a string
         
@@ -77,6 +77,8 @@ class Heading:
 
         # Join to string
         heading_string = [str(x) for x in numbers]
+        if exclude_h1:
+            heading_string.pop(0)  # remove h1 from enumeration
         heading_string = ".".join(heading_string)
 
         # Add a trailing dot to level 1 headings
@@ -84,10 +86,13 @@ class Heading:
         if "." not in heading_string:
             heading_string += "."
 
+        if heading_string == ".":
+            heading_string = ""
+
         return heading_string
 
-    def enumerate(self, add_span_element=False):
-        section_string = self.section_number_string()
+    def enumerate(self, add_span_element=False, exclude_h1=False):
+        section_string = self.section_number_string(exclude_h1=exclude_h1)
         self.heading.insert(0, " ")
 
         # Note we add both enumerate-headings-plugin and enumerate-heading-plugin

--- a/mkdocs_enumerate_headings_plugin/html_page.py
+++ b/mkdocs_enumerate_headings_plugin/html_page.py
@@ -15,17 +15,18 @@ class HTMLPage:
     def __str__(self):
         return str(self.soup)
 
-    def enumerate_headings(self, add_span_element: bool = True):
+    def enumerate_headings(self, add_span_element: bool = True, exclude_h1: bool = False):
         """
         Adds section numbering to all headings in all pages.
 
         Args:
             add_span_element (bool): Wrap numbering with <span class='enumerate-heading-plugin'></span>. Defaults to True.
+            exclude_h1 (bool): Don't count top-level gateway. Defaults to True.
         """
         for heading in self.headings:
-            heading.enumerate(add_span_element=add_span_element)
+            heading.enumerate(add_span_element=add_span_element, exclude_h1=exclude_h1)
 
-    def enumerate_toc(self, depth: int = 0):
+    def enumerate_toc(self, depth: int = 0, exclude_h1 = False):
         links = self.soup.find_all("a", href=True)
 
         for heading in self.headings:
@@ -35,7 +36,7 @@ class HTMLPage:
                     continue
                 if link.get("href") == heading.anchorlink and heading.depth <= depth:
                     link.insert(0, " ")
-                    link.insert(0, heading.section_number_string())
+                    link.insert(0, heading.section_number_string(exclude_h1=exclude_h1))
 
     def set_page_chapter(self, chapter: int) -> None:
         [h.set_chapter(chapter) for h in self.headings]

--- a/mkdocs_enumerate_headings_plugin/plugin.py
+++ b/mkdocs_enumerate_headings_plugin/plugin.py
@@ -22,6 +22,7 @@ class EnumerateHeadingsPlugin(BasePlugin):
         ("restart_increment_after", config_options.Type(list, default=[])),
         ("include", config_options.Type(list, default=["*"])),
         ("exclude", config_options.Type(list, default=[])),
+        ("exclude_h1", config_options.Type(bool, default=False)),
     )
 
     def on_pre_build(self, config, **kwargs):
@@ -182,6 +183,6 @@ class EnumerateHeadingsPlugin(BasePlugin):
         # Set chapter and enumerate the headings
         htmlpage.set_page_chapter(page.chapter)
 
-        htmlpage.enumerate_headings()
-        htmlpage.enumerate_toc(depth=self.config.get("toc_depth"))
+        htmlpage.enumerate_headings(exclude_h1=self.config.get("exclude_h1"))
+        htmlpage.enumerate_toc(depth=self.config.get("toc_depth"), exclude_h1=self.config.get("exclude_h1"))
         return str(htmlpage)


### PR DESCRIPTION
Copy of work by user @TimChaubet-I4U, who later deleted the branch. Upstream maintainer timvink has stated that they don't want to merge this feature.